### PR TITLE
fix: Update SettingAccount page with Sequelize

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -59,7 +59,6 @@ function App() {
         <Routes>
           <Route path="/" element={<Intro />} />
           <Route path="/home/:id" element={<Home token={token} />} />{' '}
-          {/* /home/:userid >> 개인별 홈화면 구현 */}
           {
             <Route
               path="/login"
@@ -67,13 +66,12 @@ function App() {
             />
           }
           {<Route path="/join" element={<SignUp />} />}
-          <Route path="/ask/:id" element={<Ask token={token} />} />{' '} {/* /ask/:id */}
+          <Route path="/ask/:id" element={<Ask token={token} />} />{' '} 
           {/* <Route path='/find' element={<회원정보 찾기 />}/> */}
           <Route path="/diary/:id" element={<Diary token={token} />} />{' '}
-          {/* /diary/:id */}
-          <Route path="/newdiary" element={<NewDiary token={token}/>} />{' '} {/* /diary/:id */}
+          <Route path="/newdiary" element={<NewDiary token={token}/>} />{' '} 
           <Route path="/contents" element={<Contents token={token}/>} />{' '}
-          <Route path="/setting" element={<SettingPage />} />
+          <Route path="/setting/:id" element={<SettingPage token={token}/>} />{' '}
           <Route path="/post" element={<Post token={token} />} />
           <Route path="/mind" element={<Mind token={token}/>} />
           <Route path="/new/:id" element={<New token={token}/>} />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -24,7 +24,7 @@ export default function Header({userId}){
          navigate('/contents', {state:{userId:userId}});
     }
     const goSetting=()=>{
-        navigate("/setting");
+        navigate(`/setting/${userId.id}`);
     }
     const Logout=()=>{
         navigate("/");

--- a/src/components/Setting/SettingAccount.js
+++ b/src/components/Setting/SettingAccount.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 
-const SettingAccount = () => {
-  const [id, setId] = useState('');
+const SettingAccount = ({token, userId}) => {
+  const [username, setUsername] = useState('');
   const [nickname, setNickname] = useState('');
   const [email, setEmail] = useState('');
   const [currentPassword, setCurrentPassword] = useState('');
@@ -11,18 +11,16 @@ const SettingAccount = () => {
   const [errors, setErrors] = useState({});
 
   useEffect(() => {
-    const fetchUserData = async () => {
-      try {
-        const response = await axios.get('/user');
-        setId(response.data.id);
-        setNickname(response.data.nickname);
-        setEmail(response.data.email);
-      } catch (error) {
-        console.error('사용자 정보를 가져오는 중 오류 발생:', error);
-      }
-    };
-
-    fetchUserData();
+    axios
+      .get('http://localhost:5000/getusername', {
+        headers: { authorization: `Bearer ${token}` },
+      })
+      .then((res) => {
+        setUsername(res.data.username);
+        setNickname(res.data.nickname);
+        setEmail(res.data.email);
+      })
+      .catch((error) => console.error('사용자 정보를 가져오는 중 오류 발생:', error));
   }, []);
 
   const validateNickname = (nickname) => {
@@ -47,39 +45,34 @@ const SettingAccount = () => {
     if (!validateEmail(email)) {
       errors.email = '유효한 이메일 형식이 아닙니다.';
     }
-    if (!validatePassword(currentPassword)){
-      errors.currentPassword = '비밀번호를 입력해주세요.';
+    if (!validatePassword(currentPassword)) {
+      errors.currentPassword = '비밀번호를 입력해주세요. (4자리 이상)';
     }
-    if (!validatePassword(newPassword)){
+    if (!validatePassword(newPassword)) {
       errors.newPassword = '새 비밀번호 / 비밀번호 확인을 입력해주세요. (4자리 이상)';
     }
-    if (currentPassword != currentPassword){
-      errors.currentPassword = '올바른 비밀번호를 입력해주세요. (4자리 이상)';
-    }
+
     setErrors(errors);
 
     if (Object.keys(errors).length === 0) {
       try {
         const requestData = {
-          id,
+          id_user: userId.id,
           nickname,
           email,
           currentPassword,
           newPassword
         };
 
-
-        console.log('front : ',requestData);
-
-        await axios.put('/user', requestData,{
-          headers:{
-            'Content-Type': 'application/json'
-          }
-        });
+        console.log('front : ', requestData);
+        await axios.post('http://localhost:5000/updateuser', {requestData},
+          {
+              headers: { authorization: `Bearer ${token}` },
+          });
         setNotification('저장되었습니다.');
         setTimeout(() => setNotification(''), 5000);
       } catch (error) {
-
+        console.error(error)
         setNotification('올바른 비밀번호를 입력해주세요.');
         setTimeout(() => setNotification(''), );
       }
@@ -94,7 +87,7 @@ const SettingAccount = () => {
       <h2>회원 정보 변경</h2>
       <div className="form-group">
         <label>아이디</label>
-        <input type="text" value={id} disabled />
+        <input type="text" value={username} disabled />
       </div>
       <div className="form-group">
         <label>닉네임</label>

--- a/src/pages/SettingPage.js
+++ b/src/pages/SettingPage.js
@@ -1,14 +1,17 @@
 import React from 'react';
+import { useParams } from "react-router-dom";
 import SettingAccount from '../components/Setting/SettingAccount';
 import Header from '../components/Header';
 import '../styles/Setting/SettingPage.css';
 
-const SettingPage = () => {
+const SettingPage = ({token}) => {
+  const userId = useParams();
+
   return (
     <div style={{ display: "flex" }}>
-      <Header />
+      <Header userId={userId}/>
       <div className="setting-page">
-        <SettingAccount />
+        <SettingAccount token={token} userId={userId}/>
       </div>
     </div>
   );


### PR DESCRIPTION
- SettingAccount 페이지 관련해서 시퀄라이즈랑 연동해 데이터를 불러오고 업데이트가 가능하도록 수정 및 구현하였습니다.

- SettingAccount 페이지에서 헤더에 UserId를 줘서 홈페이지 이동이 가능하도록 했습니다. 이것을 위해 Header에서도 SettingAccount페이지 이동 시 주소에 회원 식별번호를 추가하게 됩니다.