### PR TITLE
update/id_user props로 전달

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,10 @@ import Ask from './pages/Ask.js';
 function App() {
   //인증 관련
   const [token, setToken] = useState(localStorage.getItem('token') || '');
+  const [authUser, setAuthUser] = useState(() => {
+    const savedUser = localStorage.getItem('authUser');
+    return savedUser ? JSON.parse(savedUser) : null;
+  });
 
   const navigate = useNavigate();
 
@@ -48,15 +52,30 @@ function App() {
 
   const handleLogout = () => {
     setAuthToken('');
+    setAuthUser(null);
+    localStorage.removeItem('authUser');
     navigate('/');
   };
+  const handleLogin = (userId) => {
+    console.log('로그인한 사용자 식별번호: ', userId);
+    setAuthUser(userId);
+  };
+  useEffect(() => {
+    if (authUser) {
+      localStorage.setItem('authUser', JSON.stringify(authUser));
+    } else {
+      localStorage.removeItem('authUser');
+    }
+  }, [authUser]);
 
   return (
     <div className="App">
       <Routes>
         <Route
           path="/"
-          element={<Intro token={token} logout={handleLogout} />}
+          element={
+            <Intro token={token} logout={handleLogout} authUser={authUser} />
+          }
         />
         <Route
           path="/home/:id"
@@ -65,7 +84,9 @@ function App() {
         {
           <Route
             path="/login"
-            element={<LoginForm setToken={setAuthToken} />}
+            element={
+              <LoginForm setToken={setAuthToken} onLogin={handleLogin} />
+            }
           />
         }
         {<Route path="/join" element={<SignUp />} />}

--- a/src/components/Auth/LoginForm.js
+++ b/src/components/Auth/LoginForm.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import Modal from '../Auth/Modal';
 
-export default function LoginForm({ setToken }) {
+export default function LoginForm({ setToken, onLogin }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
 
@@ -35,6 +35,7 @@ export default function LoginForm({ setToken }) {
       setPassword('');
     } else {
       setToken(response.data.token);
+      onLogin(response.data.id_user);
       navigate(`/home/${response.data.id_user}`);
     }
   };

--- a/src/components/Intros/IntroHeader.js
+++ b/src/components/Intros/IntroHeader.js
@@ -1,14 +1,14 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import '../../styles/Intros/IntroHeader.css';
-export default function IntroHeader({ token, logout }) {
+import { useState } from 'react';
+export default function IntroHeader({ token, logout, authUser }) {
   const navigate = useNavigate();
-  const userId = useParams();
 
   const handleClick = () => {
     navigate('/login');
   };
   const goHome = () => {
-    navigate(`/home/${userId.id}`);
+    navigate(`/home/${authUser}`);
   };
   return (
     <header className="intro-header">

--- a/src/pages/Intro.js
+++ b/src/pages/Intro.js
@@ -11,10 +11,10 @@ import { FaArrowUp } from 'react-icons/fa';
 //css
 import '../styles/Intros/Intro.css';
 
-export default function Intro({ token, logout }) {
+export default function Intro({ token, logout, authUser }) {
   return (
     <div id="intro" className="intro">
-      <IntroHeader token={token} logout={logout} />
+      <IntroHeader token={token} logout={logout} authUser={authUser} />
       <main>
         <a href="#intro" class="top-btn">
           <span>위로</span>


### PR DESCRIPTION
close #156 

로그인한 사용자가 대문페이지에 바로 홈으로 이동할 수 있게 수정하였습니다. 

loginform에서 받은 id_user을 최상위 컴포넌트에 전달하고, 최상위 부모에게서 intro page, intro header가 받을 수 있게
props으로 전달하였습니다.