### PR TITLE
Fix/empty input submit error

### DIFF
--- a/src/components/Auth/LoginForm.js
+++ b/src/components/Auth/LoginForm.js
@@ -18,9 +18,16 @@ export default function LoginForm({ setToken, onLogin }) {
     e.preventDefault();
     const username = e.target.username.value;
     const password = e.target.password.value;
-
-    console.log('로그인 요청 보냄', username, password);
-
+    if (!username.trim()) {
+      setModalContent('아이디를 입력해주세요.');
+      setIsModalOpen(true);
+      return;
+    }
+    if (!password.trim()) {
+      setModalContent('비밀번호를 입력해주세요.');
+      setIsModalOpen(true);
+      return;
+    }
     const response = await axios.post(
       `${process.env.REACT_APP_API_URL}/api/login`,
       {
@@ -31,8 +38,12 @@ export default function LoginForm({ setToken, onLogin }) {
     if (response.data.success === false) {
       setModalContent(response.data.message);
       setIsModalOpen(true);
-      setUsername('');
-      setPassword('');
+      if (response.data.message === '존재하지 않는 아이디입니다.') {
+        setUsername('');
+        setPassword('');
+      } else if (response.data.message === '비밀번호를 확인해주세요.') {
+        setPassword('');
+      }
     } else {
       setToken(response.data.token);
       onLogin(response.data.id_user);

--- a/src/components/Auth/SignUpForm.js
+++ b/src/components/Auth/SignUpForm.js
@@ -18,12 +18,24 @@ export default function SignUpForm() {
   };
 
   const handleCheckDuplicate = async (e) => {
-    const { username } = inputForm;
-    const response = await axios.post(`${process.env.REACT_APP_API_URL}/api/join/check`, {
-      username,
-    });
+    const { username = '' } = inputForm;
+    //공백은 서버에 요청보내지 않음
+    if (!username.trim()) {
+      setModalContent('아이디를 입력해주세요.');
+      setIsModalOpen(true);
+      return;
+    }
+    const response = await axios.post(
+      `${process.env.REACT_APP_API_URL}/api/join/check`,
+      {
+        username,
+      }
+    );
     if (response.data.exist === true) {
       setModalContent('이미 사용중인 아이디입니다.');
+      setInputForm({ ...inputForm, username: '' });
+    } else if (response.data.error === 'blank') {
+      setModalContent('아이디를 입력해주세요.');
       setInputForm({ ...inputForm, username: '' });
     } else {
       setModalContent('사용 가능한 아이디입니다.');


### PR DESCRIPTION
closed #170

- 회원가입 페이지
아이디 중복확인할 때, 공백인 채 버튼을 누르면 에러창이 뜨는 부분 수정했습니다.
공백일 때는 서버에 요청 보내지 않도록 하였습니다. 모달창도 이에 맞게 문구를 수정하였습니다.

- 로그인 페이지
아이디, 비밀번호 입력칸이 공백일 때 바로 서버에 요청보내지 않도록 수정했습니다.
그리고 아이디, 비밀번호가 틀리면 둘 다 입력칸을 초기화하도록 했는데, 비밀번호가 틀리면 비밀번호칸만 초기화되도록 바꾸었습니다.